### PR TITLE
fix: constraint model attributes on getFormControls

### DIFF
--- a/example/src/examples/LocalConfigExample.tsx
+++ b/example/src/examples/LocalConfigExample.tsx
@@ -7,7 +7,7 @@ import { Person } from '../App';
     input: <input  placeholder="local config label" />,
 });
 
-const formControls = getFormControls<Person, 'firstName' | 'age' >([
+const formControls = getFormControls<Person, 'firstName' | 'age'>([
     {
       type: 'text',
       name: 'firstName',

--- a/src/getFormControls.tsx
+++ b/src/getFormControls.tsx
@@ -4,11 +4,11 @@ import camelCase from 'camelcase';
 import { customFormControlsBuilder } from './factories/factory';
 import { LabelControl, ReactLabelProps } from './label';
 import { InputControl, InputType, ReactInputProps } from './input';
-import { AsString, DotNotationToCamelCase, RecursiveKeyOf } from './tsUtils';
+import { DotNotationToCamelCase, RecursiveKeyOf } from './tsUtils';
 
-export interface FormControl<T> {
+export interface FormControl<T, Keys = null> {
   type: InputType;
-  name: RecursiveKeyOf<T>;
+  name: Keys extends null ? RecursiveKeyOf<T> : Keys;
 }
 
 type FormControlsReturnVal = {
@@ -16,15 +16,14 @@ type FormControlsReturnVal = {
   label: (props: ReactLabelProps) => JSX.Element;
 };
 
-type GetFormControlsReturn<KeysToReturn extends string> = Record<
-  DotNotationToCamelCase<KeysToReturn>,
+type GetFormControlsReturn<T, KeysToReturn extends string | null> = Record<
+  DotNotationToCamelCase<KeysToReturn extends string ? KeysToReturn : RecursiveKeyOf<T>>,
   FormControlsReturnVal
 >;
 
-export function getFormControls<
-  T extends object,
-  Keys extends AsString<RecursiveKeyOf<T>> = AsString<RecursiveKeyOf<T>>
->(inputControls: InputControl<T>[]): GetFormControlsReturn<Keys> {
+export function getFormControls<T extends object, Keys extends RecursiveKeyOf<T> | null = null>(
+  inputControls: InputControl<T, Keys>[]
+): GetFormControlsReturn<T, Keys> {
   const inputsArr = inputControls.reduce((inputsAcc, inputControl) => {
     return {
       ...inputsAcc,
@@ -33,7 +32,7 @@ export function getFormControls<
         label: customFormControlsBuilder(inputControl as LabelControl<T>),
       },
     };
-  }, {} as GetFormControlsReturn<Keys>);
+  }, {} as GetFormControlsReturn<T, Keys>);
 
-  return inputsArr as GetFormControlsReturn<Keys>;
+  return inputsArr as GetFormControlsReturn<T, Keys>;
 }

--- a/src/input.tsx
+++ b/src/input.tsx
@@ -30,7 +30,7 @@ export type InputType = typeof availableInputTypes[number];
 const availableFormControls = ['input', 'select', 'textarea'] as const;
 type FormControlType = typeof availableFormControls[number];
 
-export interface InputControl<T> extends FormControl<T> {
+export interface InputControl<T, Keys = null> extends FormControl<T, Keys> {
   componentType?: FormControlType;
 }
 

--- a/src/tsUtils.ts
+++ b/src/tsUtils.ts
@@ -15,5 +15,3 @@ export type RecursiveKeyOf<TObj extends ObjectType<TObj>> = {
 export type DotNotationToCamelCase<S extends string> = S extends `${infer T}.${infer U}`
   ? `${Lowercase<T>}${Capitalize<DotNotationToCamelCase<U>>}`
   : S;
-
-export type AsString<S extends string> = S extends string ? S : S;


### PR DESCRIPTION
Closes #1

This MR adds better TS support, when only some Model attributes are specified in the `getFormControls` function